### PR TITLE
add zero dev execute(bytes32,bytes)

### DIFF
--- a/chain-config/base/erc4337.json
+++ b/chain-config/base/erc4337.json
@@ -25,6 +25,13 @@
       "entrypoint_address": "0x0000000071727de22e5e9d8baf0edac6f37da032",
       "entrypoint_function_name": "handleOps",
       "entrypoint_function_abi": "function handleOps((address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes)[], address)",
+      "scw_function_name": "execute",
+      "scw_function_abi": "function execute(bytes32,bytes)"
+    },
+    {
+      "entrypoint_address": "0x0000000071727de22e5e9d8baf0edac6f37da032",
+      "entrypoint_function_name": "handleOps",
+      "entrypoint_function_abi": "function handleOps((address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes)[], address)",
       "scw_function_name": "executeBatch",
       "scw_function_abi": "function executeBatch(address[],uint256[],bytes[])"
     }

--- a/test/chains/base.test.json
+++ b/test/chains/base.test.json
@@ -9,6 +9,15 @@
                     "to": "0xe55fEE191604cdBeb874F87A28Ca89aED401C303"
                 }
             ]
+        },
+        {
+            "txHash": "0x8b24e7613094d84ece44b09405d084304aa6c0e0805ae6f474fbcb7c773f00fc",
+            "expected": [
+                {
+                    "from": "0x7894bE1adC87DFc755De3C41Dc22eEbA59df0D8e",
+                    "to": "0x132363a3bbf47e06cf642dd18e9173e364546c99"
+                }
+            ]
         }
     ]
 } 


### PR DESCRIPTION
We are using ZeroDev to handle our AA interactions. Unfortunately, I couldn't get the test to pass despite using many different possible `from` and `to` variables. Please advise. 