### PR TITLE
Add arbitrum configuration & support custom userOp

### DIFF
--- a/chain-config/arbitrum/erc4337.json
+++ b/chain-config/arbitrum/erc4337.json
@@ -27,6 +27,15 @@
       "entrypoint_function_abi": "function handleOps((address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes)[], address)",
       "scw_function_name": "executeBatch",
       "scw_function_abi": "function executeBatch(address[],uint256[],bytes[])"
+    },
+    {
+      "entrypoint_address": "0x701c09edf9369954d7687f7d1c03002dc79371cb",
+      "entrypoint_function_name": "handleOps",
+      "entrypoint_function_abi": "function handleOps((address,uint256,bytes,bytes,bytes)[])",
+      "scw_function_name": "transfer",
+      "scw_function_abi": "function transfer(address,uint256)",
+      "op_calldata_index": 2,
+      "op_calldata_skip_bytes": 20
     }
   ]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ export interface ERC4337Config {
     entrypoint_function_abi: string;
     scw_function_name: string;
     scw_function_abi: string;
+    op_calldata_index: number;
+    op_calldata_skip_bytes: number;
 }
 
 export interface ChainConfig {

--- a/src/utils/decoder.ts
+++ b/src/utils/decoder.ts
@@ -40,12 +40,12 @@ export async function decodeUserOperation(
 
             for (const userOp of decoded[0]) {
                 try {
-                    const callData = userOp[keyToIndexMap['callData']];
+                    const callData = ethers.dataSlice(userOp[conf.op_calldata_index || keyToIndexMap['callData']], conf.op_calldata_skip_bytes || 0);
                     const scwCallDataDecoded = scwFuncIface.decodeFunctionData(
                         conf.scw_function_name,
                         callData
                     );
-                    
+
                     let to;
                     if (isAddressFieldDefined) {
                         if (Array.isArray(scwCallDataDecoded[0])) {

--- a/test/chains/arbitrum.test.json
+++ b/test/chains/arbitrum.test.json
@@ -9,6 +9,19 @@
                     "to": "0x21DFb0a12D77f4e0D2cF9008d0C2643d1e36DA41"
                 }
             ]
+        },
+        {
+            "txHash": "0x34e2fb232833c62a24bcd479dade298a0ea2ba88160d57031873cb7176afca71",
+            "expected": [
+                {
+                    "from": "0xBFE627a78876148848D8D5395412325d25CCC3Bd",
+                    "to": "0x0F23c82C5E146e8ea1d11Cb087B9929B3A6065D0"
+                },
+                {
+                    "from": "0x28801C0E71E0D082c2878789cebcD4fE8943e3Ae",
+                    "to": "0xBFE627a78876148848D8D5395412325d25CCC3Bd"
+                }
+            ]
         }
     ]
 } 


### PR DESCRIPTION
MiL.k project are using custom UserOperation struct that has no `initData` field and `callData` starts with `target contract address(normally ERC20 contract)`.
So, I added `op_calldata_index`, `op_calldata_skip_bytes` configuration features.